### PR TITLE
Add trailing slash to $(SolutionDir) for includes

### DIFF
--- a/cmake_converter/utils.py
+++ b/cmake_converter/utils.py
@@ -271,7 +271,7 @@ def make_os_specific_shell_path(output):
 def resolve_path_variables_of_vs(context, path_with_vars):
     """ Evaluates paths with visual studio variables """
     path_with_vars = path_with_vars.replace('$(ProjectDir)', './')
-    path_with_vars = path_with_vars.replace('$(SolutionDir)', context.solution_path)
+    path_with_vars = path_with_vars.replace('$(SolutionDir)', context.solution_path + '/')
     return path_with_vars
 
 


### PR DESCRIPTION
Fixes issues with no trailing slash in `<AdditionalIncludeDirectories>`. I discovered this while using CMake Converter on https://github.com/jedisct1/libsodium/blob/master/libsodium.vcxproj. If you have suggestions or other ideas on how this should be implemented, let me know. Thanks!