### PR TITLE
parse environment variables in paths

### DIFF
--- a/cmake_converter/dependencies.py
+++ b/cmake_converter/dependencies.py
@@ -31,7 +31,8 @@ import os
 import re
 
 from cmake_converter.data_files import get_vcxproj_data
-from cmake_converter.utils import get_global_project_name_from_vcxproj_file, normalize_path, message
+from cmake_converter.utils import get_global_project_name_from_vcxproj_file, normalize_path, message, \
+    parse_env_vars_in_vs_fmt
 from cmake_converter.utils import replace_vs_vars_with_cmake_vars, resolve_path_variables_of_vs
 
 
@@ -66,6 +67,7 @@ class Dependencies:
         for i in inc_dir.split(';'):
             if i:
                 dirs_raw.append(i)
+                i = parse_env_vars_in_vs_fmt(i)
                 i = normalize_path(context, working_path, i)
                 i = replace_vs_vars_with_cmake_vars(context, i)
                 inc_dirs.append(i)

--- a/cmake_converter/utils.py
+++ b/cmake_converter/utils.py
@@ -322,6 +322,16 @@ def replace_vs_var_with_cmake_var(context, var):
     return cmake_env_var
 
 
+def parse_env_vars_in_vs_fmt(path):
+    if '$(' in path:
+        matches = re.findall(r'\$\(.*?\)', path, flags=re.MULTILINE | re.DOTALL)
+        for match in matches:
+            var = os.path.expanduser(os.path.expandvars('$' + match[2:-1]))
+            if '$(' not in var:
+                path = path.replace(match, var)
+    return path
+
+
 def replace_vs_vars_with_cmake_vars(context, output):
     """ Translates variables at given string to corresponding CMake ones """
     var_ex = re.compile(r'(\$\(.*?\))')

--- a/cmake_converter/utils.py
+++ b/cmake_converter/utils.py
@@ -40,7 +40,6 @@ def init_colorama():
     if 'PYCHARM_HOSTED' in os.environ:
         convert = False  # in PyCharm, we should disable convert
         strip = False
-        print("Hi! You are using PyCharm")
     else:
         convert = None
         strip = None

--- a/cmake_converter/visual_studio/solution.py
+++ b/cmake_converter/visual_studio/solution.py
@@ -128,7 +128,7 @@ class VSSolutionConverter(DataConverter):
         :return:
         """
         p = re.compile(
-            r'(Project.*\s=\s\"(.*)\",\s\"(.*)\",.*({.*\})(?:.|\n)*?EndProject(?!Section))'
+            r'(Project.*\s=\s\"(.*)\",\s\"(.*)\",.*({.*})(?:.|\n)*?EndProject(?!Section))'
         )
 
         for project_data_match in p.findall(sln_text):

--- a/cmake_converter/visual_studio/solution.py
+++ b/cmake_converter/visual_studio/solution.py
@@ -132,7 +132,7 @@ class VSSolutionConverter(DataConverter):
         )
 
         for project_data_match in p.findall(sln_text):
-            path = set_native_slash(project_data_match[2])
+            path = os.path.expanduser(os.path.expandvars(set_native_slash(project_data_match[2])))
             guid = project_data_match[3]
 
             _, ext = os.path.splitext(os.path.basename(path))

--- a/cmake_converter/visual_studio/vcxproj/dependencies.py
+++ b/cmake_converter/visual_studio/vcxproj/dependencies.py
@@ -30,7 +30,8 @@ import re
 from cmake_converter.dependencies import Dependencies
 from cmake_converter.data_files import get_xml_data, get_propertygroup
 from cmake_converter.utils import normalize_path, message, prepare_build_event_cmd_line_for_cmake, \
-    check_for_relative_in_path, cleaning_output, set_native_slash, get_mount_point
+    check_for_relative_in_path, cleaning_output, set_native_slash, get_mount_point, replace_vs_vars_with_cmake_vars, \
+    parse_env_vars_in_vs_fmt
 from cmake_converter.flags import ln_flags
 
 
@@ -56,9 +57,16 @@ class VCXDependencies(Dependencies):
 
         del attr_name, node
 
+        path = attr_value
+        path = parse_env_vars_in_vs_fmt(path)
+        path = replace_vs_vars_with_cmake_vars(context, path)
+
+        if not os.path.isabs(path):
+            path = os.path.join(os.path.dirname(context.vcxproj_path), attr_value)
+
         ref = self.get_dependency_target_name(
             context,
-            os.path.join(os.path.dirname(context.vcxproj_path), attr_value)
+            path
         )
 
         context.target_references.append(ref)


### PR DESCRIPTION
Without these changes, conversion fails when paths include environment variables. These changes expand system and user environment variables, as well as VS-style environment variables. When a VS-style variable cannot be resolved because the variable is not an environment variable, conversion may still fail.