### PR TITLE
fix(vfproj): add missing VFFortranCompilerTool flags

### DIFF
--- a/cmake_converter/visual_studio/vfproj/flags.py
+++ b/cmake_converter/visual_studio/vfproj/flags.py
@@ -71,6 +71,7 @@ class FortranFlags(Flags):
             ('VFFortranCompilerTool_RealKIND', self.__set_real_kind),
             ('VFFortranCompilerTool_LocalVariableStorage', self.__set_local_variable_storage),
             ('VFFortranCompilerTool_InitLocalVarToNAN', self.__set_init_local_var_to_nan),
+            ('VFFortranCompilerTool_LocalSavedScalarsZero', self.__set_init_local_var_to_zero),
             ('VFFortranCompilerTool_FloatingPointExceptionHandling',
              self.__set_floating_point_exception_handling),
             ('VFFortranCompilerTool_ExtendSinglePrecisionConstants',
@@ -659,6 +660,20 @@ class FortranFlags(Flags):
         return flag_values
 
     @staticmethod
+    def __set_init_local_var_to_zero(context, flag_name, flag_value):
+        """
+        Set init local var to Zero flag
+        """
+        del context, flag_name, flag_value
+        flag_values = {
+            'true': {ifort_cl_win: '-Qzero',
+                     ifort_cl_unix: '-zero'},
+            default_value: {}
+        }
+        return flag_values
+
+
+    @staticmethod
     def __set_preprocess_source_file(context, flag_name, flag_value):
         """
         Set preprocess source file flag
@@ -828,6 +843,8 @@ class FortranFlags(Flags):
         flag_values = {
             'localStorageAutomatic': {ifort_cl_win: '-Qauto',
                                       ifort_cl_unix: '-auto'},
+            'localStorageSave': {ifort_cl_win: '-Qsave',
+                                 ifort_cl_unix: '-save'},
             default_value: {}
         }
         return flag_values

--- a/cmake_converter/visual_studio/vfproj/flags.py
+++ b/cmake_converter/visual_studio/vfproj/flags.py
@@ -60,6 +60,13 @@ class FortranFlags(Flags):
             ('VFFortranCompilerTool_DisableSpecificDiagnostics',
              self.__set_disable_specific_diagnostics),
             ('VFFortranCompilerTool_Diagnostics', self.__set_diagnostics),
+            ('VFFortranCompilerTool_CommonElementAlignment', self.__set_common_element_align),
+            ('VFFortranCompilerTool_ArrayAlignment', self.__set_default_array_align),
+            ('VFFortranCompilerTool_AlignSEQUENCE', self.__set_sequence_type_align),
+            ('VFFortranCompilerTool_HeapArrays', self.__set_heap_arrays),
+            ('VFFortranCompilerTool_LocalSavedScalarsZero', self.__set_local_saved_scalars_zero),
+            ('VFFortranCompilerTool_Parallelization', self.__set_parallelization),
+            ('VFFortranCompilerTool_PrefetchInsertionOpt', self.__set_prefetch_insertion_opt),
             ('VFFortranCompilerTool_WarnDeclarations', self.__set_warn_declarations),
             ('VFFortranCompilerTool_WarnUnusedVariables', self.__set_warn_unused_variables),
             ('VFFortranCompilerTool_WarnIgnoreLOC', self.__set_warn_ignore_loc),
@@ -177,7 +184,8 @@ class FortranFlags(Flags):
             ifort_ln_unix,
             'assume_args',
             'warn_args',
-            'check_args'
+            'check_args',
+            'align_args'
         ]
 
         for flag_name in self.flags_handlers:
@@ -192,6 +200,7 @@ class FortranFlags(Flags):
 
         self.__set_spec_options(context, 'assume_args', 'assume')
         self.__set_spec_options(context, 'check_args', 'check')
+        self.__set_spec_options(context, 'align_args', 'align')
         self.__set_spec_options(context, 'warn_args', 'warn')
 
     @staticmethod
@@ -264,6 +273,79 @@ class FortranFlags(Flags):
                                    ifort_cl_unix: '-warn all'},
             'diagnosticsDisableAll': {ifort_cl_win: '-warn:none',
                                       ifort_cl_unix: '-warn none'},
+            default_value: {}
+        }
+        return flag_values
+
+    @staticmethod
+    def __set_common_element_align(context, flag_name, flag_value):
+        del context, flag_name, flag_value
+        flag_values = {
+            'alignCommonFourBytes' : {'align_args': 'commons'},
+            'alignCommonEightBytes': {'align_args': 'dcommons'},
+            'alignCommon16Bytes': {'align_args': 'qcommons'},
+            'alignCommon32Bytes': {'align_args': 'zcommons'},
+        }
+        return flag_values
+
+    @staticmethod
+    def __set_default_array_align(context, flag_name, flag_value):
+        del context, flag_name, flag_value
+        flag_values = {
+            'alignArray8Bytes' : {'align_args': 'array8byte'},
+            'alignArray16Bytes': {'align_args': 'array16byte'},
+            'alignArray32Bytes': {'align_args': 'array32byte'},
+            'alignArray64Bytes': {'align_args': 'array64byte'},
+            'alignArray128Bytes': {'align_args': 'array128byte'},
+            'alignArray256Bytes': {'align_args': 'array256byte'},
+        }
+        return flag_values
+
+    @staticmethod
+    def __set_sequence_type_align(context, flag_name, flag_value):
+        del context, flag_name, flag_value
+        flag_values = {
+            'true': {'align_args': 'sequence'}
+        }
+        return flag_values
+
+    def __set_heap_arrays(self, context, flag_name, flag_value):
+        del context
+        # value must be a list with ',' separator
+        opt = flag_value
+        if opt:
+            self.flags[flag_name][ifort_cl_win] = ['-heap-arrays:{}'.format(opt)]
+            self.flags[flag_name][ifort_cl_unix] = ['-heap-arrays={}'.format(opt)]
+
+    @staticmethod
+    def __set_local_saved_scalars_zero(context, flag_name, flag_value):
+        del context, flag_name, flag_value
+        flag_values = {
+            'true': {ifort_cl_win: '-Qzero',
+                     ifort_cl_unix: '-zero'},
+            'false': {},
+            default_value: {}
+        }
+        return flag_values
+
+    @staticmethod
+    def __set_parallelization(context, flag_name, flag_value):
+        del context, flag_name, flag_value
+        flag_values = {
+            'true': {ifort_cl_win: '-Qparallel',
+                     ifort_cl_unix: '-parallel'},
+            'false': {},
+            default_value: {}
+        }
+        return flag_values
+
+    @staticmethod
+    def __set_prefetch_insertion_opt(context, flag_name, flag_value):
+        del context, flag_name, flag_value
+        flag_values = {
+            'prefetchMinimum': {ifort_cl_win: '-Qopt-prefetch:1', ifort_cl_unix: '-qopt-prefetch=1'},
+            'prefetchMedium': {ifort_cl_win: '-Qopt-prefetch:2', ifort_cl_unix: '-qopt-prefetch=2'},
+            'prefetchAggresive': {ifort_cl_win: '-Qopt-prefetch:3', ifort_cl_unix: '-qopt-prefetch=3'},
             default_value: {}
         }
         return flag_values

--- a/cmake_converter/visual_studio/vfproj/parser.py
+++ b/cmake_converter/visual_studio/vfproj/parser.py
@@ -80,6 +80,9 @@ class VFParser(Parser):
             'VFFortranCompilerTool_WarnUnalignedData': self.__parse_concrete_diagnostics,
             'VFFortranCompilerTool_WarnUncalled': self.__parse_concrete_diagnostics,
             'VFFortranCompilerTool_SuppressUsageMessages': self.__parse_concrete_diagnostics,
+            'VFFortranCompilerTool_CommonElementAlign': self.__parse_align_value,
+            'VFFortranCompilerTool_ArrayAlign': self.__parse_align_value,
+            'VFFortranCompilerTool_AlignSEQUENCE': self.__parse_align_value,
             'VFFortranCompilerTool_RuntimeChecks': self.__parse_runtime_checks,
             'VFFortranCompilerTool_NullPointerCheck': self.__parse_concrete_runtime_checks,
             'VFFortranCompilerTool_BoundsCheck': self.__parse_concrete_runtime_checks,
@@ -233,6 +236,9 @@ class VFParser(Parser):
 
     def __parse_concrete_runtime_checks(self, context, attr_name, attr_value, node):
         if self.common_runtime_checks_value is None:
+            context.flags.set_flag(context, attr_name, attr_value, node)
+
+    def __parse_align_value(self, context, attr_name, attr_value, node):
             context.flags.set_flag(context, attr_name, attr_value, node)
 
     def __parse_files(self, context, filter_node):

--- a/cmake_converter/visual_studio/vfproj/utils.py
+++ b/cmake_converter/visual_studio/vfproj/utils.py
@@ -63,3 +63,4 @@ class VFUtils(Utils):
         context.settings[context.current_setting]['check_args'] = []
         context.settings[context.current_setting]['target_type'] = 'Application'
         context.settings[context.current_setting]['Fortran_MODULE_DIRECTORY'] = []
+        context.settings[context.current_setting]["align_args"] = []


### PR DESCRIPTION
Some Fortran procedures require that the compiler additional compiler flags to run correctly.

In Visual Studio, the `.vfproj` file contains options for the: 
- `LocalSavedScalarsZero` attribute to set `Qzero`/`zero`
- `LocalVariableStorage` attribute to set `Qsave`/`save`
- `CommonElementAlignment`, `ArrayAlignment`, `AlignSEQUENCE` attributes to set `align`
- `HeapArrays` attribute to set `heap-arrays`
- `Parallelization` to set `parallel`
- PrefetchInsertionOpt to set `Qopt-prefetch`/`qopt-prefetch`

Have all been added.