### PR TITLE
VS path environment variables now correctly evaluated

### DIFF
--- a/cmake_converter/visual_studio/solution.py
+++ b/cmake_converter/visual_studio/solution.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2016-2020:
 #   Matthieu Estrada, ttamalfor@gmail.com
 #   Pavel Liavonau, liavonlida@gmail.com
+#   Keon Amini, keon.a380@gmail.com
 #
 # This file is part of (CMakeConverter).
 #
@@ -303,7 +304,6 @@ class VSSolutionConverter(DataConverter):
         """
         Routine converts Visual studio solution into set of CMakeLists.txt scripts
         """
-
         message(
             project_context, '------- Started parsing solution {} -------'.format(sln_file_path), ''
         )


### PR DESCRIPTION
If the proj files reference header-file directory paths set by environment variables (e.g. $(foo_dir)), the current code does not correctly evaluate those directories in the final CMake file and throws a bunch of warnings saying `getting actual filesystem name failed`. This solution fixes that problem - already tested on one Visual Studio project successfully and compiled it with CLion.